### PR TITLE
Add 'platform_code' in 'stops.txt'

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -68,4 +68,6 @@
 * Version 0.8 du 25/03/2019
     * Ajout de la gestion des pathways
 * Version 0.9 du 16/05/2019
-    * AJout du nouveau modèle tarifaire
+    * Ajout du nouveau modèle tarifaire
+* Version 0.9.1 du 18/07/2019
+	* Ajout des `platform_code` dans `stops.txt`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -333,6 +333,7 @@ parent_station | chaine | Optionnel | Identifiant de la zone d'arrêt. Ne doit p
 stop_timezone | timezones | Optionnel | Fuseau horaire, se référer à http://en.wikipedia.org/wiki/List_of_tz_zones
 equipment_id | chaine | Optionnel | Identifiant de la propriété accessibilité
 level_id | chaine | Optionnel | lien vers un niveau décrit dans le fichier [`levels.txt`](#levelstxt-optionnel)
+platform_code | chaine | Optionnel | Identifiant de la plateforme d'un arrêt (par exemple `G` ou `3`). Ne peut être renseigné que pour les arrêts physiques (`location_type=0`) ou les zones d'embarquements (`location_type=5`)
 
     (1) Type de l'arrêt ou de la zone :
         0 ou non spécifié - Arrêt physique (objet stop_point)


### PR DESCRIPTION
`platform_code` comes from the GTFS specification (see [`stops.txt`](https://developers.google.com/transit/gtfs/reference/#stopstxt)). Please review carefully as I'm not a data and/or model expert.