### PR TITLE
New name and specs for date_time_estimated

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -75,5 +75,5 @@
     * Suppression des champs `forward_direction` et `backward_direction` dans `lines.txt`
 * Version 0.10.0 du 11/09/2019
     * Ajout du champ `trip_short_name` et `stop_short_name`
-* Version 0.10.1 du 11/10/2019
+* Version 0.11.0 du 11/10/2019
     * Modification du nom et de la gestion pour le champ `date_time_estimated` dans `stop_times.txt`

--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -75,3 +75,5 @@
     * Suppression des champs `forward_direction` et `backward_direction` dans `lines.txt`
 * Version 0.10.0 du 11/09/2019
     * Ajout du champ `trip_short_name` et `stop_short_name`
+* Version 0.10.1 du 11/10/2019
+    * Modification du nom et de la gestion pour le champ `date_time_estimated` dans `stop_times.txt`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -358,7 +358,7 @@ trip_short_name_at_stop | chaine | Optionnel | Nom qui doit être affiché au vo
 pickup_type | entier (1) | Optionnel | Indication sur l'horaire (issues du gtfs)
 drop_off_type | entier (1) | Optionnel | Indication sur l'horaire (issues du gtfs)
 local_zone_id  | entier | Optionnel | identifiant de la zone d'ITL de l'horaire
-stop_time_type | entier (2) | Optionnel | Précise si l'heure de passage est fiable ou si elle est donnée à titre indicative
+stop_time_precision | entier (2) | Optionnel | Précise si l'heure de passage est fiable ou si elle est donnée à titre indicative
 
     (1) Indication sur l'horaire (issues du gtfs) :
         0 (par défaut) - Horaire régulier
@@ -367,7 +367,7 @@ stop_time_type | entier (2) | Optionnel | Précise si l'heure de passage est fia
 
     (2) La fiabilité peut prendre les valeurs suivantes :
         0 - L'heure de passage est fiable, i.e. l'horaire est exact.
-        1 - L'heure de passage est approximative (correspond au cas du GTFS où timepoint vaut 0), e.g. un horaire associé à un arrêt de regulation.
+        1 - L'heure de passage est approximative (correspond au cas du GTFS où timepoint vaut 0), e.g. un horaire régulier mais qui n'est pas associé à un arrêt de régulation.
         2 - L'heure de passage n'est pas garantie, e.g. l'horaire estimé d'un TAD.
         non spécifiée :
             s'il s'agit d'un horaire associé à une zone (stop de location_type de valeur 2) : l'heure n'est pas garantie

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -358,7 +358,7 @@ trip_short_name_at_stop | chaine | Optionnel | Nom qui doit être affiché au vo
 pickup_type | entier (1) | Optionnel | Indication sur l'horaire (issues du gtfs)
 drop_off_type | entier (1) | Optionnel | Indication sur l'horaire (issues du gtfs)
 local_zone_id  | entier | Optionnel | identifiant de la zone d'ITL de l'horaire
-date_time_estimated | entier (2) | Optionnel | Précise si l'heure de passage est fiable ou si elle est donnée à titre indicative
+stop_time_type | entier (2) | Optionnel | Précise si l'heure de passage est fiable ou si elle est donnée à titre indicative
 
     (1) Indication sur l'horaire (issues du gtfs) :
         0 (par défaut) - Horaire régulier
@@ -366,10 +366,11 @@ date_time_estimated | entier (2) | Optionnel | Précise si l'heure de passage es
         2 - Horaire sur réservation associé à un TAD (si un message est associé au TAD, voir la liaison avec [`comment_links.txt`](#comment_linkstxt-optionnel))
 
     (2) La fiabilité peut prendre les valeurs suivantes :
-        0 - L'heure de passage est fiable
-        1 - L'heure de passage est estimée
+        0 - L'heure de passage est fiable, i.e. l'horaire est exact.
+        1 - L'heure de passage est approximative (correspond au cas du GTFS où timepoint vaut 0), e.g. un horaire associé à un arrêt de regulation.
+        2 - L'heure de passage n'est pas garantie, e.g. l'horaire estimé d'un TAD.
         non spécifiée :
-            s'il s'agit d'un horaire associé à une zone (stop de location_type de valeur 2 ou 3) : l'heure est estimée
+            s'il s'agit d'un horaire associé à une zone (stop de location_type de valeur 2) : l'heure n'est pas garantie
             sinon, l'heure de passage est fiable
 
 ### transfers.txt (optionnel)


### PR DESCRIPTION
I propose this modification so that the notion of the GTFS timepoint is more clear and at the same time, ODT stop_times are handled correctly.