### PR TITLE
Add Journey Pattern in the model

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -77,3 +77,5 @@
     * Ajout du champ `trip_short_name` et `stop_short_name`
 * Version 0.11.0 du 11/10/2019
     * Modification du nom et de la gestion pour le champ `date_time_estimated` dans `stop_times.txt`
+* Version 0.11.1 du 03/02/2020
+    * Ajout du champ `journey_pattern_id` dans `trips.txt`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -422,6 +422,7 @@ physical_mode_id | chaine | Requis | Identifiant du mode physique (lien vers le 
 trip_property_id | chaine | Optionnel | Identifiant de la propriété accessibilité (lien vers le fichier [`trip_properties.txt`](#trip_propertiestxt-optionnel))
 dataset_id | chaine | Requis | Identifiant du jeu de données ayant fourni la circulation (lien vers le fichier [`datasets.txt`](#datasetstxt-requis)).
 geometry_id | chaine | Optionnel | Identifiant du tracé représentant la circulation (lien vers le fichier [`geometries.txt`](#geometriestxt-optionnel))
+journey_pattern_id | chaine | Optionnel | Identifiant de la mission (i.e. une séquence ordonnée d'arrêts ayant les mêmes propriétés et parfois connue du voyageur)
 
     Pour préciser si la circulation est sur réservation (tout ou partie), il faut :
         Indiquer au niveau de l'horaire (fichier [`stop_times.txt`](#stop_timestxt-requis)) si la montée et/ou la descente est à réservation


### PR DESCRIPTION
In `transit_model`, we often have to convert from/to data format containing the notion of Journey Pattern. This is relatively expensive to calculate a Journey Pattern so the idea raised up to actually store it in the NTFS format.

Since we're using the terminology `trip` and not `vehicle_journey`, I named it `trip_pattern` instead of `vehicle_journey_pattern` or `journey_pattern`. And in order to keep everything backward compatible, I made this file optional for now.