### PR TITLE
Add 'tartare_datasource_id' in 'feed_infos.txt'

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -85,3 +85,5 @@
 * Version 0.11.2 du 26/02/2020
     * Amélioration de la description du modèle tarifaire
     * Ajout d'un champ `feed_creation_datetime` recommandé dans `feed_infos.txt`
+* Version 0.11.3 (pas encore taggée)
+    * Ajout d'un champ `tartare_datasource_id` dans `feed_infos.txt`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -570,6 +570,7 @@ fusio_version | chaine | Libre | Version du système ayant généré le jeu de d
 tartare_platform | chaine | Libre | Tag indiquant la plateforme qui a généré les données
 tartare_coverage_id | chaine | Libre | Id du coverage Tartare ayant généré le jeu de données (1)
 tartare_contributor_id | chaine | Libre | Id du contributeur Tartare ayant généré le jeu de données (1)
+tartare_datasource_id | chaine | Libre | Id du datasource Tartare généré
 
     (1) seul l'un des champs `tartare_coverage_id` et `tartare_contributor_id` sera présent. Il servent a tracer la source de la donnée dans Tartare afin de faciliter les diagnostiques.
 


### PR DESCRIPTION
A new field used at Kisio Digital and traced into `feed_infos.txt`.