### PR TITLE
[doc] Improve description of 'network_address'

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -85,3 +85,5 @@
 * Version 0.11.2 du 26/02/2020
     * Amélioration de la description du modèle tarifaire
     * Ajout d'un champ `feed_creation_datetime` recommandé dans `feed_infos.txt`
+* Version 0.11.3 du 10/09/2020
+    * Amélioration de documentation des champs `network_address`, `stop_timezone` et `feed_creation_date`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -95,7 +95,7 @@ network_url | chaine | Optionnel | Lien vers le site institutionnel
 network_timezone | chaine | Optionnel |
 network_lang | chaine | Optionnel |
 network_phone | chaine | Optionnel | Numéro de téléphone de contact
-network_address | chaine | Optionnel | Adresse du réseau.
+network_address | chaine | Optionnel | Adresse postale du réseau.
 network_sort_order | entier | Optionnel | Ordre de trie des réseaux, les plus petit sont en premier.
 
 ### calendar.txt (requis)


### PR DESCRIPTION
Tiny precision of which type of address for `network_address` (it is not an email address, it is a mailing address).