### PR TITLE
[doc] improve documentation for 'object_properties' and 'object_codes'

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -89,3 +89,5 @@
     * Amélioration de documentation des champs `network_address`, `stop_timezone` et `feed_creation_date`
 * Version 0.11.4 du 27/09/2020
     * Ajout de la gestion des codes externes pour les compagnies
+* Version 0.11.5 du 12/04/2021
+    * Amélioration de documentation pour `object_properties` et `object_codes`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -449,6 +449,7 @@ geometry_wkt | géométrie | Requis | Représentation spatiale de la géométrie
 ### object_properties.txt (optionnel)
 Ce fichier contient la description des propriétés complémentaires sur les différents objets du référentiel.
 Ces propriétés sont sous forme de liste de clés / valeurs qui doivent être standardisées par processus.
+Une clé ne peut être utilisée qu'une seule fois (avec une seule valeur) pour un même objet.
 
 Colonne | Type | Contrainte | Commentaire
 --- | --- | --- | ---
@@ -460,6 +461,7 @@ object_property_value | chaine | Requis | Valeur de la propriété complémentai
 ### object_codes.txt (optionnel)
 Ce fichier contient la liste des codes d'identification complémentaires dans les systèmes externes des différents objets du référentiel.
 Ces propriétés sont sous forme de liste de clés / valeurs qui doivent être standardisées par processus.
+Une clé peut être utilisée plusieurs fois (avec des valeurs différentes) pour un même objet.
 
 Colonne | Type | Contrainte | Commentaire
 --- | --- | --- | ---


### PR DESCRIPTION
I had difficulties to find the information in the specification, but it feels that the rules around `object_properties` and `object_codes` are slightly different, even if they're both key-values elements.

In `object_codes`, you might have multiple code of the same type. For example, if you decide to regroup `stop_area` by distance, you might want to keep all the codes of the original `stop_area`s in the following form:
-  key: `stop_area_origin`, value: `stop_area1`
-  key: `stop_area_origin`, value: `stop_area2`

But for `object_properties` it seems that you can't have the same key use multiple times. For example, you wouldn't want the following situation for the properties of a `line` object because you would not be able to decide which color is the line.
- key: `color`, value: `magenta`
- key: `color`, value: `purple`