### PR TITLE
docs: specify the unit for CO2

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -99,3 +99,5 @@
     * Les `stop_times` peuvent maintenant être des points de passage (pas d'arrêt du véhicule)
 * Version 0.12.2 du 20/10/2021
     * Correction de la documentation sur `date_time_estimated` qui est maintenant `stop_time_precision`
+* Version 0.12.3 du 31/05/2022
+    * Précision de documentation concernant l'unité utilisée pour le CO2

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -254,7 +254,7 @@ Colonne | Type | Contrainte | Commentaire
 --- | --- | --- | ---
 physical_mode_id | chaine | Requis | Identifiant du mode physique obligatoirement dans la liste ci-dessous.
 physical_mode_name | chaine | Requis | Nom du mode physique
-co2_emission | décimal | Optionnel | Taux d’émission de CO2 du mode physique par voyageur et par km.
+co2_emission | décimal | Optionnel | Taux d’émission de CO2 du mode physique en grammes par voyageur et par km.
 
 **Liste des modes physique disponible :**
 


### PR DESCRIPTION
Usually, ADEME is communicating around CO2 in kg, but I realized that we usually put grams in NTFS so better make it explicit.