### PR TITLE
feat: add 'occupancies.txt' file

### DIFF
--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -101,5 +101,5 @@
     * Correction de la documentation sur `date_time_estimated` qui est maintenant `stop_time_precision`
 * Version 0.12.3 du 31/05/2022
     * Précision de documentation concernant l'unité utilisée pour le CO2
-* Version 0.13.0 du 22/12/2022
+* Version 0.13.0 du 25/04/2023
     * Ajout du fichier optionnel `occupancies.txt`

--- a/ntfs_changelog_fr.md
+++ b/ntfs_changelog_fr.md
@@ -101,3 +101,5 @@
     * Correction de la documentation sur `date_time_estimated` qui est maintenant `stop_time_precision`
 * Version 0.12.3 du 31/05/2022
     * Précision de documentation concernant l'unité utilisée pour le CO2
+* Version 0.13.0 du 22/12/2022
+    * Ajout du fichier optionnel `occupancies.txt`

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -72,7 +72,7 @@ Fichier | Contrainte | Commentaire
 [`pathways.txt`](#pathwaystxt-optionnel) | Optionnel | Ce fichier contient les cheminements au sein d'une zone d'arrêt. Ces cheminements ne sont pas nécessairement géographiques, il peut y avoir des simplifications.
 [`levels.txt`](#levelstxt-optionnel) | Optionnel | Ce fichier contient la liste des niveaux au sein d'une zone d'arrêt.
 [`addresses.txt`](#addressestxt-optionnel) | Optionnel | Ce fichier contient la liste des adresses des arrêts physiques.
-[`occupancies.txt`](#occupanciestxt-optionnel) | Optionnel | Ce fichier contient les informations d'affluence sur le réseau
+[`occupancies.txt`](#occupanciestxt-optionnel) | Optionnel | Ce fichier contient les informations d'affluence sur le réseau [**expérimental**]
 
 ## Fichiers des calendriers par période
 Fichier | Contrainte | Commentaire
@@ -529,7 +529,7 @@ address_id | chaine | Requis | Identifiant de l'adresse
 street_name | chaine | Requis | Nom de la voierie
 house_number | chaine | Optionnel | Numéro du seuil
 
-### occupancies.txt (optionnel)
+### occupancies.txt (optionnel) [**expérimental**]
 La notion d'affluence est appliquée sur l'intervalle entre 2 horaires (affluence à bord du véhicule).
 Pour chaque ligne de ce fichier, l'affluence est appliquée à tous les intervalles d'une circulation entre deux horaires (successifs ou non) remplissant l'ensemble des conditions suivantes :
 

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -72,6 +72,7 @@ Fichier | Contrainte | Commentaire
 [`pathways.txt`](#pathwaystxt-optionnel) | Optionnel | Ce fichier contient les cheminements au sein d'une zone d'arrêt. Ces cheminements ne sont pas nécessairement géographiques, il peut y avoir des simplifications.
 [`levels.txt`](#levelstxt-optionnel) | Optionnel | Ce fichier contient la liste des niveaux au sein d'une zone d'arrêt.
 [`addresses.txt`](#addressestxt-optionnel) | Optionnel | Ce fichier contient la liste des adresses des arrêts physiques.
+[`occupancies.txt`](#occupanciestxt-optionnel) | Optionnel | Ce fichier contient les informations d'affluence sur le réseau
 
 ## Fichiers des calendriers par période
 Fichier | Contrainte | Commentaire
@@ -527,6 +528,48 @@ Colonne | Type | Contrainte | Commentaire
 address_id | chaine | Requis | Identifiant de l'adresse
 street_name | chaine | Requis | Nom de la voierie
 house_number | chaine | Optionnel | Numéro du seuil
+
+### occupancies.txt (optionnel)
+Pour chaque ligne de ce fichier, l'affluence est appliquée à toutes les paires d'horaires successifs d'une circulation remplissant l'ensemble des conditions suivantes :
+
+* les poteaux d'arrêts des deux horaires se trouvent entre `from_stop_area` et `to_stop_area` (inclus)
+* le jour de circulation est inclus entre `from_date` et `to_date`
+* le jour de semaine de la circulation est actif (voir champs `monday`, `tuesday`, etc.)
+* les `departure_time` des deux horaires sont inclus entre `from_time` et `to_time` (inclus)
+* il est possible de monter dans le véhicule sur le premier des deux horaires successifs
+* il est possible de descendre dans le véhicule sur le dernier des deux horaires successifs
+
+Les lignes du fichier sont appliquées dans l'ordre.
+
+Colonne | Type | Contrainte | Commentaire
+--- | --- | --- | ---
+line_id | chaine | Requis | Identifiant de la ligne concernées
+from_stop_area | chaine | Requis | Identifiant de la zone d'arrêt à partir de laquelle s'applique l'affluence
+to_stop_area | chaine | Requis | Identifiant de la zone d'arrêt jusqu'à laquelle s'applique l'affluence
+from_date | date | Requis | Date à partir de laquelle s'applique l'affluence
+to_date | date | Requis | Date jusqu'à laquelle s'applique l'affluence
+from_time | heure | Requis | Heure à partir de laquelle s'applique l'affluence, appliquée sur chacun des jours entre `from_date` et `to_date`
+to_time | heure | Requis | Heure jusqu'à laquelle s'applique l'affluence, appliquée sur chacun des jours entre `from_date` et `to_date`
+occupancy | occupancy (1) | Requis | L'affluence à appliquer
+monday | booléen | Optionnel | Indique si l'affluence s'applique sur les lundis entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+tuesday | booléen | Optionnel | Indique si l'affluence s'applique sur les mardis entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+wednesday | booléen | Optionnel | Indique si l'affluence s'applique sur les mercredis entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+thursday | booléen | Optionnel | Indique si l'affluence s'applique sur les jeudis entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+friday | booléen | Optionnel | Indique si l'affluence s'applique sur les vendredis entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+saturday | booléen | Optionnel | Indique si l'affluence s'applique sur les samedis entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+sunday | booléen | Optionnel | Indique si l'affluence s'applique sur les dimanches entre `from_date` et `to_date`. L'affluence s'applique par défaut.
+
+(1) la valeur est une énumération basée sur les niveaux d'affluence définis dans le GTFS-RT (voir [`OccupancyStatus`](https://developers.google.com/transit/gtfs-realtime/reference/#enum-occupancystatus):
+
+* EMPTY
+* MANY_SEATS_AVAILABLE
+* FEW_SEATS_AVAILABLE
+* STANDING_ROOM_ONLY
+* CRUSHED_STANDING_ROOM_ONLY
+* FULL
+* NOT_ACCEPTING_PASSENGERS
+* NO_DATA_AVAILABLE
+* NOT_BOARDABLE
 
 ### line_groups.txt (optionnel)
 Colonne | Type | Contrainte | Commentaire

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -72,7 +72,7 @@ Fichier | Contrainte | Commentaire
 [`pathways.txt`](#pathwaystxt-optionnel) | Optionnel | Ce fichier contient les cheminements au sein d'une zone d'arrêt. Ces cheminements ne sont pas nécessairement géographiques, il peut y avoir des simplifications.
 [`levels.txt`](#levelstxt-optionnel) | Optionnel | Ce fichier contient la liste des niveaux au sein d'une zone d'arrêt.
 [`addresses.txt`](#addressestxt-optionnel) | Optionnel | Ce fichier contient la liste des adresses des arrêts physiques.
-[`occupancies.txt`](#occupanciestxt-optionnel) | Optionnel | Ce fichier contient les informations d'affluence sur le réseau [**expérimental**]
+[`occupancies.txt`](#occupanciestxt-optionnel-expérimental) | Optionnel | Ce fichier contient les informations d'affluence sur le réseau [**expérimental**]
 
 ## Fichiers des calendriers par période
 Fichier | Contrainte | Commentaire

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -98,7 +98,7 @@ network_timezone | chaine | Optionnel |
 network_lang | chaine | Optionnel |
 network_phone | chaine | Optionnel | Numéro de téléphone de contact
 network_address | chaine | Optionnel | Adresse postale du réseau.
-network_sort_order | entier | Optionnel | Ordre de trie des réseaux, les plus petit sont en premier.
+network_sort_order | entier | Optionnel | Ordre de tri des réseaux, les plus petits sont en premier.
 
 ### calendar.txt (requis)
 Ce fichier décrit les périodes de circulation associés aux trips.

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -530,14 +530,15 @@ street_name | chaine | Requis | Nom de la voierie
 house_number | chaine | Optionnel | Numéro du seuil
 
 ### occupancies.txt (optionnel)
-Pour chaque ligne de ce fichier, l'affluence est appliquée à toutes les séries d'horaires successifs d'une circulation remplissant l'ensemble des conditions suivantes :
+La notion d'affluence est appliquée sur l'intervalle entre 2 horaires (affluence à bord du véhicule).
+Pour chaque ligne de ce fichier, l'affluence est appliquée à tous les intervalles d'une circulation entre deux horaires (successifs ou non) remplissant l'ensemble des conditions suivantes :
 
-* les poteaux d'arrêts des horaires se trouvent entre `from_stop_area` et `to_stop_area` (inclus)
-* le jour de circulation est inclus entre `from_date` et `to_date`
+* le premier des intervalles débute à l'arrêt `from_stop_area` et le dernier des intervalles se termine l'arrêt `to_stop_area` (inclus)
+* le jour de circulation est inclus entre `from_date` et `to_date` (inclus)
 * le jour de semaine de la circulation est actif (voir champs `monday`, `tuesday`, etc.)
-* les `departure_time` des horaires sont inclus entre `from_time` et `to_time` (inclus)
-* il est possible de monter dans le véhicule sur le premier des horaires
-* il est possible de descendre dans le véhicule sur le dernier des horaires
+* le `departure_time` du premier intervalle et le `arrival_time` du dernier intervalle sont inclus entre `from_time` et `to_time` (inclus)
+* il est possible de monter dans le véhicule à l'arrêt `from_stop_area`
+* il est possible de descendre du véhicule à l'arrêt `to_stop_area`
 
 Les lignes du fichier sont appliquées dans l'ordre.
 

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -530,14 +530,14 @@ street_name | chaine | Requis | Nom de la voierie
 house_number | chaine | Optionnel | Numéro du seuil
 
 ### occupancies.txt (optionnel)
-Pour chaque ligne de ce fichier, l'affluence est appliquée à toutes les paires d'horaires successifs d'une circulation remplissant l'ensemble des conditions suivantes :
+Pour chaque ligne de ce fichier, l'affluence est appliquée à toutes les séries d'horaires successifs d'une circulation remplissant l'ensemble des conditions suivantes :
 
-* les poteaux d'arrêts des deux horaires se trouvent entre `from_stop_area` et `to_stop_area` (inclus)
+* les poteaux d'arrêts des horaires se trouvent entre `from_stop_area` et `to_stop_area` (inclus)
 * le jour de circulation est inclus entre `from_date` et `to_date`
 * le jour de semaine de la circulation est actif (voir champs `monday`, `tuesday`, etc.)
-* les `departure_time` des deux horaires sont inclus entre `from_time` et `to_time` (inclus)
-* il est possible de monter dans le véhicule sur le premier des deux horaires successifs
-* il est possible de descendre dans le véhicule sur le dernier des deux horaires successifs
+* les `departure_time` des horaires sont inclus entre `from_time` et `to_time` (inclus)
+* il est possible de monter dans le véhicule sur le premier des horaires
+* il est possible de descendre dans le véhicule sur le dernier des horaires
 
 Les lignes du fichier sont appliquées dans l'ordre.
 

--- a/ntfs_fr.md
+++ b/ntfs_fr.md
@@ -1,5 +1,5 @@
-NTFS version 0.12
-=================
+Spécification NTFS
+==================
 
 # Introduction
 


### PR DESCRIPTION
This is a first draft for filling up vehicle occupancy information in a public transport plan.

Occupancy is needed between each pair of successive `stop_time` on a `trip` on a specific day. But filling up information for each and every of these pair of `stop_time` would be:
- fastidious: there are a lot of successive pairs of `stop_time`
- difficult: it's not  always easy to find out which `trip`, easier to reason by `line`
- huge: the size of such a file would be enormous, possibly bigger than `stop_times.txt` because each `stop_time` would need multiple lines for each calendar day of the trip's service

One current known limitation of the current draft is the impossibility to describe the following scenario: one trip goes through the stops A-B-C and the second trip goes through A-C (without intermediate stops). If you define occupancy with the current version of the file, it's hard to define 2 different occupancy for these 2 trips. It's technically possible by:
- first defining the occupancy for trip 2 between A-C (but this would also put occupancy on trip 1)
- then defining, later in the file, A-B then B-C for trip 1 (precedence rule would override occupancies already set up in first rule, and trip 2 would not be picked up because you can't board in or drop off on B).

But this is not an ideal solution for maintenance reason.